### PR TITLE
Fix interval throwing error depending on the platform

### DIFF
--- a/src/AwsRequest/PutPart.ts
+++ b/src/AwsRequest/PutPart.ts
@@ -31,7 +31,7 @@ class PutPart extends PartialSignedS3AWSRequest {
   public partNumber: number
   public start: number = 0
   public end: number = 0
-  public stalledInterval: number = null
+  public stalledInterval: ReturnType<typeof setInterval> = null
   public result: any
   static size: number
 

--- a/src/FileUpload/FileUpload.ts
+++ b/src/FileUpload/FileUpload.ts
@@ -37,9 +37,9 @@ import { Defer, Dictionary } from '../Types'
 
 class FileUpload
   implements
-    UploadFileConfig,
-    Pick<Evaporate, 'localTimeOffset'>,
-    Pick<EvaporateConfigInterface, 'signParams'> {
+  UploadFileConfig,
+  Pick<Evaporate, 'localTimeOffset'>,
+  Pick<EvaporateConfigInterface, 'signParams'> {
   public fileTotalBytesUploaded: number = 0
   public s3Parts: S3Part[]
   public partsOnS3: S3File[] = []
@@ -59,7 +59,7 @@ class FileUpload
   public startTime: Date
   public status: EVAPORATE_STATUS = EVAPORATE_STATUS.PENDING
 
-  public progressInterval: number
+  public progressInterval: ReturnType<typeof setInterval>
   public uploadId: string
   public firstMd5Digest: string
   public eTag: string
@@ -90,25 +90,25 @@ class FileUpload
   public xAmzHeadersAtComplete: Dictionary<string> = {}
   public xAmzHeadersCommon: Dictionary<string> = null
 
-  public nameChanged: (awsObjectKey: string) => void = () => {}
-  public uploadInitiated: (s3UploadId?: string) => void = () => {}
-  public beforeSigner?: (xhr: XMLHttpRequest, url: string) => void = () => {}
+  public nameChanged: (awsObjectKey: string) => void = () => { }
+  public uploadInitiated: (s3UploadId?: string) => void = () => { }
+  public beforeSigner?: (xhr: XMLHttpRequest, url: string) => void = () => { }
 
-  public started: (file_key: string) => void = () => {}
-  public progress: (p: number, stats: S3UploadStatsInterface) => void = () => {}
-  public paused: (file_key?: string) => void = () => {}
-  public resumed: (file_key?: string) => void = () => {}
-  public pausing: (file_key?: string) => void = () => {}
-  public cancelled: () => void = () => {}
+  public started: (file_key: string) => void = () => { }
+  public progress: (p: number, stats: S3UploadStatsInterface) => void = () => { }
+  public paused: (file_key?: string) => void = () => { }
+  public resumed: (file_key?: string) => void = () => { }
+  public pausing: (file_key?: string) => void = () => { }
+  public cancelled: () => void = () => { }
   public complete: (
     xhr: XMLHttpRequest,
     awsObjectKey: string,
     stats: S3UploadStatsInterface
-  ) => void = () => {}
+  ) => void = () => { }
 
-  public info: (...msg: string[]) => void = () => {}
-  public warn: (...msg: string[]) => void = () => {}
-  public error: (msg: string) => void = () => {}
+  public info: (...msg: string[]) => void = () => { }
+  public warn: (...msg: string[]) => void = () => { }
+  public error: (msg: string) => void = () => { }
 
   updateLoaded(loadedNow: number): void {
     this.loaded += loadedNow
@@ -706,7 +706,7 @@ class FileUpload
       self.partsToUpload = []
 
       return self.uploadParts().then(
-        () => {},
+        () => { },
         (reason: string) => {
           throw reason
         }


### PR DESCRIPTION
Fix the dynamic returning type of setInterval per platform (node or web) throwing errors depending on each platform you ran it into.

For instance, if you tried to run the library on a node-like env, let's say for instance ava tests, it would complain that the type is not NodeJS.Timeout.

By doing this change, we avoid this problem.